### PR TITLE
feat: Add Binder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # examples
 A set of differentiable analysis examples.
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gradhep/differentiable-analysis-examples/HEAD)
+
 ## setup
 
 Clone this repo, then in your virtual environment (Python 3.7+):

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,5 @@
+celluloid
+git+http://github.com/scikit-hep/pyhf.git@make_difffable_model_ctor
+plothelp
+neos==0.3.0
+relaxed==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-celluloid
-git+http://github.com/scikit-hep/pyhf.git@make_difffable_model_ctor
-plothelp
-neos==0.3.0
-relaxed==0.2.1
+binder/requirements.txt


### PR DESCRIPTION
* Move `requirements.txt` under `binder/` dir to ensure Binder will build environment from `binder/requirements.txt`.
* Add symbolic link from `binder/requirements.txt` to `requirements.txt` at the top level to make it easier for people to still install the environment from the top level of the repository.
* Add Binder launch badge to README

Preview: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gradhep/differentiable-analysis-examples/HEAD)